### PR TITLE
add --pretokenized flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The script `evaluate_tokenizer.py` loads tokenizer (pre-saved or from hugging fa
 - Vocabulary Overlap measured by Jensen-Shannon divergence between in-language distributions;
 - Vocabulary Allocation measured by average rank of the token in in-language distribution.
 - Vocabulary Allocation measured by the average number of characters for a token in specific language.
-- Coverage, i.e. 1 - the share of unkown tokens in the tokenized text.
+- Coverage, i.e. 1 - the share of unknown tokens in the tokenized text.
 
 The results are saved as a json file `tokenizer_properties.json`. To run the evaluation run the following command (with exemplary parameters):
 
@@ -42,7 +42,8 @@ python evaluate_tokenizer.py \
     --languages en en es pl \
     --tokenizer_name xlm-roberta-base \
     --output_dir /home/tokenizers_evaluation \
-    [--unk_token <unk>]
+    [--unk_token <unk>] \
+    [--pretokenized]
 ```
 
 The explanation of the parameters:
@@ -50,8 +51,9 @@ The explanation of the parameters:
 - languages: listed languages of the data for each data path
 - tokenizer_name: HF tokenizer name or name of the tokenizer pre-saved in the output directory
 - output_dir: path to output directory to save the results
-- unk_token: optional, the unkonwn token in the vocabulary (by default `<unk>`)
-
+- unk_token: optional, the unknown token in the vocabulary (by default `<unk>`)
+- pretokenized: optional (default=False), use if data was previously tokenized by a specific subword tokenizer, and saved with spaces between subwords.
+  `tokenizer_name` must match the tokenizer that was used.
 
 ## Reproducing the experiments
 

--- a/src/compute_token_frequency.py
+++ b/src/compute_token_frequency.py
@@ -83,8 +83,13 @@ def compute_frequencies(data_list, tokenizer, name="token_frequencies", pretoken
                 if pretokenized:
                     for tokenized_line in line_batch:
                         for tok in tokenized_line.split():
-                            idx = vocab[tok]
-                            counter[idx] += 1
+                            try:
+                                idx = vocab[tok]
+                                counter[idx] += 1
+                            except KeyError as e:
+                                print(f"Token '{tok}' not in vocabulary. Please ensure the tokenizer matches the "
+                                      f"tokenized data.")
+                                raise e
                 else:
                     for tokenized_line in tokenizer(line_batch)["input_ids"]:
                         for idx in tokenized_line:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,10 @@
 import json
 import os
 from collections import OrderedDict
+
 from transformers import XLMRobertaTokenizerFast
+
+from notebooks.notebook_utils import distribution_from_frequencies
 
 
 def load_config(config_path):
@@ -27,26 +30,22 @@ def get_tokenizer_from_model_config(model_config, language):
 
     return tokenizer, lang_offset
 
-import os
-from collections import OrderedDict
-
-from notebooks.notebook_utils import distribution_from_frequencies
-
 
 def load_config(config_path):
     with open(config_path, 'r') as fp:
         return json.load(fp)
-    
-    
-def get_distributions_over_decoded_vocabulary_default(result_dir: str, languages: list[str]) -> (OrderedDict, OrderedDict):
+
+
+def get_distributions_over_decoded_vocabulary_default(tokenizer_dir: str, languages: list[str]) -> (
+        OrderedDict, OrderedDict):
     """
     Get the distribution over the vocabulary for each language. For given tokenizer.
     """
-    
+
     frequencies_over_vocabulary = {}
     for lang in languages:
-        tokenizer_stats_path = os.path.join(result_dir, f"token_freq_{lang}_decoded.json")
-        
+        tokenizer_stats_path = os.path.join(tokenizer_dir, f"token_freq_{lang}_decoded.json")
+
         try:
             frequencies_over_vocabulary[lang] = json.load(open(tokenizer_stats_path, 'r'))
         except FileNotFoundError:
@@ -54,8 +53,8 @@ def get_distributions_over_decoded_vocabulary_default(result_dir: str, languages
             continue
             
     # multilingual frequency file
-    tokenizer_stats_path = os.path.join(result_dir, f"token_frequencies_decoded.json")
-    
+    tokenizer_stats_path = os.path.join(tokenizer_dir, f"token_frequencies_decoded.json")
+
     try:
         frequencies_over_vocabulary["All"] = json.load(open(tokenizer_stats_path, 'r'))
     except FileNotFoundError:


### PR DESCRIPTION
to allow the script to read already-tokenized data.
I've moved the loading of the tokenizer to the main() function because it seemed cleaner than loading it somewhere hidden -> the various file path things are handled outside of the metrics calculation.

Please do test that it still runs.

### Extra context:
I've disentangled this from the `tokenizer_type` flag and MODELS_BY_TYPE situation that you may have also seen. While that was convenient for me, it wasn't actually clean and logically connected to the "pretokenized" flag.

So as it is right now, the script would still assume that the tokenizer either is or should be saved in the output directory. This didn't work for me when I was using tokenizers saved elsewhere on the system but wanted to write the script output to my own files.

I MAY end up making the ability to use a tokenizer saved somewhere else, with a short name, another PR down the line, but right now it's admittedly not a priority to clean up that code.